### PR TITLE
fix #58 - disable eslint strict rule in load-reps.js

### DIFF
--- a/src/reps/load-reps.js
+++ b/src/reps/load-reps.js
@@ -3,6 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Disable eslint strict rule because the eslint env ("es6") is incompatible with eslint
+// validation in MC (https://github.com/devtools-html/devtools-reps/issues/58)
+/* eslint-disable strict */
+
 // Make this available to both AMD and CJS environments
 define(function (require, exports, module) {
   let REPS;

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /* eslint no-unused-vars: [2, {"vars": "local"}] */
 
+"use strict";
+
 var { classes: Cc, interfaces: Ci, utils: Cu, results: Cr } = Components;
 
 var { require } = Cu.import("resource://devtools/shared/Loader.jsm", {});


### PR DESCRIPTION
We can either disable as proposed here or modify the copy-assets script to add "use strict" dynamically in load-reps.

This PR also adds a "use strict" in test head file.

Weirdly eslint src/**/*.js ignores files in src/test/ . See https://github.com/eslint/eslint/issues/1663#issuecomment-240066799
I don't want to "fix" this here because head.js is full of eslint errors when checked against this repo's rules.

A more robust eslint approach here would be to have all files supposed to be copied to mc in a subfolder, with a dedicated .eslint rc that could set the env (and certain rules) to be inline with mc.