### PR TITLE
copy load-reps & reps.css from src in copy-assets.js

### DIFF
--- a/bin/copy-assets.js
+++ b/bin/copy-assets.js
@@ -15,13 +15,13 @@ function start() {
   symlinkTests({ projectPath, mcModulePath });
 
   copyFile(
-    path.join(projectPath, "./assets/build/load-reps.js"),
+    path.resolve(projectPath, "src/reps/load-reps.js"),
     path.join(mcPath, mcModulePath, "load-reps.js"),
     {cwd: projectPath}
   );
 
   copyFile(
-    path.join(projectPath, "./assets/build/reps.css"),
+    path.resolve(projectPath, "src/reps/reps.css"),
     path.join(mcPath, mcModulePath, "reps.css"),
     {cwd: projectPath}
   );


### PR DESCRIPTION
This PR updates the copy-assets script to no longer rely on the content of assets/build (and therefore no longer rely on publish-assets).

This is inline with what the debugger does (https://github.com/devtools-html/debugger.html/blob/master/bin/copy-assets.js), with the major exception that the debugger has the mc-specific source files in the "assets" dir (the locales and prefs here).

For reps this would mean moving reps.css and load-reps.js to /assets 
But since these two files get deployed in reps/ in mc, I'd prefer to keep it consistent here and keep them in src/reps. 

cc @nchevobbe #60  