### PR TITLE
Allow customization of object rep's title generation

### DIFF
--- a/src/reps/object.js
+++ b/src/reps/object.js
@@ -28,7 +28,7 @@ const Obj = React.createClass({
     if (this.props.objectLink) {
       return this.props.objectLink({
         object: object
-      }, className);
+      }, title);
     }
     return title;
   },

--- a/src/reps/object.js
+++ b/src/reps/object.js
@@ -16,20 +16,21 @@ const Obj = React.createClass({
   displayName: "Obj",
 
   propTypes: {
-    object: React.PropTypes.object,
+    object: React.PropTypes.object.isRequired,
     // @TODO Change this to Object.values once it's supported in Node's version of V8
     mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
     objectLink: React.PropTypes.func,
+    title: React.PropTypes.string,
   },
 
   getTitle: function (object) {
-    let className = object && object.class ? object.class : "Object";
+    let title = this.props.title || object.class || "Object";
     if (this.props.objectLink) {
       return this.props.objectLink({
         object: object
       }, className);
     }
-    return className;
+    return title;
   },
 
   safePropIterator: function (object, max) {

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -45,14 +45,17 @@ function shallowRenderComponent(component, props) {
 /**
  * Test that a rep renders correctly across different modes.
  */
-function testRepRenderModes(modeTests, testName, componentUnderTest, gripStub) {
+function testRepRenderModes(modeTests, testName, componentUnderTest, gripStub, props = {}) {
   modeTests.forEach(({mode, expectedOutput, message}) => {
     const modeString = typeof mode === "undefined" ? "no mode" : mode.toString();
     if (!message) {
       message = `${testName}: ${modeString} renders correctly.`;
     }
 
-    const rendered = renderComponent(componentUnderTest.rep, { object: gripStub, mode });
+    const rendered = renderComponent(
+      componentUnderTest.rep,
+      Object.assign({}, { object: gripStub, mode }, props)
+    );
     is(rendered.textContent, expectedOutput, message);
   });
 }

--- a/src/test/mochitest/test_reps_object.html
+++ b/src/test/mochitest/test_reps_object.html
@@ -252,7 +252,7 @@ window.onload = Task.async(function* () {
       "testCustomTitle", 
       componentUnderTest, 
       stub, {
-        title:
+        title: customTitle
       }
     );
   }

--- a/src/test/mochitest/test_reps_object.html
+++ b/src/test/mochitest/test_reps_object.html
@@ -35,6 +35,9 @@ window.onload = Task.async(function* () {
 
     // Test that 'more' property doesn't clobber the caption.
     yield testMoreProp();
+
+    // Test that you can pass a custom title to the Rep
+    yield testCustomTitle();
   } catch(e) {
     ok(false, "Got an error: " + DevToolsUtils.safeErrorString(e));
   } finally {
@@ -218,7 +221,42 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, "testMoreProp", componentUnderTest, stub);
-  }});
+  }
+
+  function testCustomTitle() {
+    const customTitle = "MyCustomObject";
+    const stub = {a: "a", b: "b", c: "c"};
+    const defaultOutput = `${customTitle} { a: "a", b: "b", c: "c" }`;
+
+    const modeTests = [
+      {
+        mode: undefined,
+        expectedOutput: defaultOutput,
+      },
+      {
+        mode: MODE.TINY,
+        expectedOutput: customTitle,
+      },
+      {
+        mode: MODE.SHORT,
+        expectedOutput: defaultOutput,
+      },
+      {
+        mode: MODE.LONG,
+        expectedOutput: defaultOutput,
+      }
+    ];
+
+    testRepRenderModes(
+      modeTests, 
+      "testCustomTitle", 
+      componentUnderTest, 
+      stub, {
+        title:
+      }
+    );
+  }
+});
 </script>
 </pre>
 </body>


### PR DESCRIPTION
Changes copied from https://hg.mozilla.org/integration/mozilla-inbound/rev/fb66941fca47 by yzen.
I added a test to make sure we can indeed pass a custom title to the rep.