### PR TITLE
Configure window reps title

### DIFF
--- a/src/reps/grip-array.js
+++ b/src/reps/grip-array.js
@@ -41,9 +41,10 @@ let GripArray = React.createClass({
   getTitle: function (object, context) {
     let objectLink = this.props.objectLink || span;
     if (this.props.mode !== MODE.TINY) {
+      let title = this.props.title || object.class || "Array";
       return objectLink({
         object: object
-      }, object.class + " ");
+      }, title, " ");
     }
     return "";
   },

--- a/src/reps/grip-array.js
+++ b/src/reps/grip-array.js
@@ -85,12 +85,16 @@ let GripArray = React.createClass({
 
         items.push(GripArrayItem(Object.assign({}, this.props, {
           object: value,
-          delim: delim
+          delim: delim,
+          // Do not propagate title to array items reps
+          title: undefined,
         })));
       } catch (exc) {
         items.push(GripArrayItem(Object.assign({}, this.props, {
           object: exc,
-          delim: delim
+          delim: delim,
+          // Do not propagate title to array items reps
+          title: undefined,
         })));
       }
     }

--- a/src/reps/grip-map.js
+++ b/src/reps/grip-map.js
@@ -26,10 +26,11 @@ const GripMap = React.createClass({
     onDOMNodeMouseOver: React.PropTypes.func,
     onDOMNodeMouseOut: React.PropTypes.func,
     onInspectIconClick: React.PropTypes.func,
+    title: React.PropTypes.string,
   },
 
   getTitle: function (object) {
-    let title = object && object.class ? object.class : "Map";
+    let title = this.props.title || (object && object.class ? object.class : "Map");
     if (this.props.objectLink) {
       return this.props.objectLink({
         object: object

--- a/src/reps/grip.js
+++ b/src/reps/grip.js
@@ -138,6 +138,8 @@ const GripRep = React.createClass({
         equal: ": ",
         delim: i !== indexes.length - 1 || truncate ? ", " : "",
         defaultRep: Grip,
+        // Do not propagate title to properties reps
+        title: undefined,
       })));
     });
 

--- a/src/reps/window.js
+++ b/src/reps/window.js
@@ -8,6 +8,8 @@ const {
   wrapRender
 } = require("./rep-utils");
 
+const { MODE } = require("./constants");
+
 // Shortcuts
 const DOM = React.DOM;
 
@@ -18,33 +20,49 @@ let Window = React.createClass({
   displayName: "Window",
 
   propTypes: {
+    // @TODO Change this to Object.values once it's supported in Node's version of V8
+    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
     object: React.PropTypes.object.isRequired,
     objectLink: React.PropTypes.func,
+    title: React.PropTypes.string,
   },
 
-  getTitle: function (grip) {
+  getTitle: function (object) {
+    let title = this.props.title || object.class || "Window";
     if (this.props.objectLink) {
       return DOM.span({className: "objectBox"},
         this.props.objectLink({
-          object: grip
-        }, grip.class + " ")
+          object
+        }, title)
       );
     }
-    return "";
+    return title;
   },
 
-  getLocation: function (grip) {
-    return getURLDisplayString(grip.preview.url);
+  getLocation: function (object) {
+    return getURLDisplayString(object.preview.url);
   },
 
   render: wrapRender(function () {
-    let grip = this.props.object;
+    let {
+      mode,
+      object,
+    } = this.props;
+
+    if (mode === MODE.TINY) {
+      return (
+        DOM.span({className: "objectBox objectBox-Window"},
+          this.getTitle(object)
+        )
+      );
+    }
 
     return (
       DOM.span({className: "objectBox objectBox-Window"},
-        this.getTitle(grip),
+        this.getTitle(object),
+        " ",
         DOM.span({className: "objectPropValue"},
-          this.getLocation(grip)
+          this.getLocation(object)
         )
       )
     );

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -47,7 +47,7 @@ function shallowRenderComponent(component, props) {
  */
 function testRepRenderModes(modeTests, testName, componentUnderTest, gripStub,
   props = {}) {
-  modeTests.forEach(({mode, expectedOutput, message}) => {
+  modeTests.forEach(({mode, expectedOutput, message, title}) => {
     const modeString = typeof mode === "undefined" ? "no mode" : mode.toString();
     if (!message) {
       message = `${testName}: ${modeString} renders correctly.`;
@@ -55,7 +55,7 @@ function testRepRenderModes(modeTests, testName, componentUnderTest, gripStub,
 
     const rendered = renderComponent(
       componentUnderTest.rep,
-      Object.assign({}, { object: gripStub, mode }, props)
+      Object.assign({}, { object: gripStub, mode, title }, props)
     );
     is(rendered.textContent, expectedOutput, message);
   });

--- a/src/test/mochitest/test_reps_event.html
+++ b/src/test/mochitest/test_reps_event.html
@@ -116,7 +116,7 @@ window.onload = Task.async(function* () {
     });
     is(longRenderedComponent.textContent,
        `message { target: http://example.com, isTrusted: false, data: "test data", ` +
-       `origin: "null", lastEventId: "", source: , ports: message, currentTarget: , ` +
+       `origin: "null", lastEventId: "", source: , ports: Array, currentTarget: , ` +
        `eventPhase: 2, bubbles: false, 1 more… }`,
        "Event rep has expected text content for a message event in long mode");
   }

--- a/src/test/mochitest/test_reps_event.html
+++ b/src/test/mochitest/test_reps_event.html
@@ -49,8 +49,8 @@ window.onload = Task.async(function* () {
       object: getGripStub("testEvent"),
     });
     is(renderedComponent.textContent,
-      "beforeprint { target: http://example.com, isTrusted: true, " +
-      "currentTarget: http://example.com, 8 more… }",
+      "beforeprint { target: Window, isTrusted: true, " +
+      "currentTarget: Window, 8 more… }",
       "Event rep has expected text content for an event");
   }
 
@@ -106,7 +106,7 @@ window.onload = Task.async(function* () {
       object: getGripStub("testMessageEvent")
     });
     is(renderedComponent.textContent,
-       `message { target: http://example.com, isTrusted: false, data: "test data", ` +
+       `message { target: Window, isTrusted: false, data: "test data", ` +
        "8 more… }",
        "Event rep has expected text content for a message event");
 
@@ -115,9 +115,9 @@ window.onload = Task.async(function* () {
       mode: MODE.LONG,
     });
     is(longRenderedComponent.textContent,
-       `message { target: http://example.com, isTrusted: false, data: "test data", ` +
-       `origin: "null", lastEventId: "", source: , ports: Array, currentTarget: , ` +
-       `eventPhase: 2, bubbles: false, 1 more… }`,
+       `message { target: Window, isTrusted: false, data: "test data", ` +
+       `origin: "null", lastEventId: "", source: Window, ports: Array, ` +
+       `currentTarget: Window, eventPhase: 2, bubbles: false, 1 more… }`,
        "Event rep has expected text content for a message event in long mode");
   }
 

--- a/src/test/mochitest/test_reps_grip-array.html
+++ b/src/test/mochitest/test_reps_grip-array.html
@@ -108,6 +108,13 @@ window.onload = Task.async(function* () {
       {
         mode: MODE.LONG,
         expectedOutput: defaultOutput,
+      },
+      {
+        // Check the custom title with nested objects to make sure nested objects are not
+        // displayed with their parent's title.
+        mode: MODE.LONG,
+        title: "CustomTitle",
+        expectedOutput: `CustomTitle [ 1, "foo", Object ]`,
       }
     ];
 

--- a/src/test/mochitest/test_reps_grip-map.html
+++ b/src/test/mochitest/test_reps_grip-map.html
@@ -138,6 +138,13 @@ window.onload = Task.async(function* () {
       {
         mode: MODE.LONG,
         expectedOutput: defaultOutput,
+      },
+      {
+        // Check the custom title with nested objects to make sure nested objects are not
+        // displayed with their parent's title.
+        mode: MODE.LONG,
+        title: "CustomTitle",
+        expectedOutput: `CustomTitle { Object: "value-a" }`,
       }
     ];
 

--- a/src/test/mochitest/test_reps_grip.html
+++ b/src/test/mochitest/test_reps_grip.html
@@ -460,6 +460,13 @@ window.onload = Task.async(function* () {
       {
         mode: MODE.LONG,
         expectedOutput: defaultOutput,
+      },
+      {
+        // Check the custom title with nested objects to make sure nested objects are not
+        // displayed with their parent's title.
+        mode: MODE.LONG,
+        title: "CustomTitle",
+        expectedOutput: `CustomTitle { objProp: Object, strProp: "test string" }`,
       }
     ];
 

--- a/src/test/mochitest/test_reps_window.html
+++ b/src/test/mochitest/test_reps_window.html
@@ -21,7 +21,7 @@ window.onload = Task.async(function* () {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");
     let React = browserRequire("devtools/client/shared/vendor/react");
 
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/load-reps");
+    const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/load-reps");
     let { Rep, Window } = REPS;
 
     let gripStub = {
@@ -45,8 +45,39 @@ window.onload = Task.async(function* () {
     // Test rendering
     const renderedComponent = renderComponent(Window.rep, { object: gripStub });
     ok(renderedComponent.className.includes("objectBox-Window"), "Window rep has expected class name");
+    is(renderedComponent.textContent, "Window about:newtab", "Window rep has expected text content");
     const innerNode = renderedComponent.querySelector(".objectPropValue");
     is(innerNode.textContent, "about:newtab", "Window rep has expected inner HTML structure and text content");
+
+    const tinyRenderedComponent = renderComponent(Window.rep, {
+      object: gripStub,
+      mode: MODE.TINY,
+    });
+    is(tinyRenderedComponent.textContent, "Window",
+       "Window rep has expected text content in TINY mode");
+
+    const longRenderedComponent = renderComponent(Window.rep, {
+      object: gripStub,
+      mode: MODE.LONG,
+    });
+    is(longRenderedComponent.textContent, "Window about:newtab",
+       "Window rep has expected text content in LONG mode");
+
+    const customTitleRenderedComponent = renderComponent(Window.rep, {
+      object: gripStub,
+      mode: MODE.TINY,
+      title: "Custom"
+    });
+    is(customTitleRenderedComponent.textContent, "Custom",
+       "Window rep has expected text content in TINY mode with Custom title");
+
+    const customTitleLongRenderedComponent = renderComponent(Window.rep, {
+      object: gripStub,
+      mode: MODE.LONG,
+      title: "Custom"
+    });
+    is(customTitleLongRenderedComponent.textContent, "Custom about:newtab",
+       "Window rep has expected text content in LONG mode with Custom title");
   } catch(e) {
     ok(false, "Got an error: " + DevToolsUtils.safeErrorString(e));
   } finally {


### PR DESCRIPTION
This is an attempt at fixing #47 

Instead of introducing the debugger.html specific isGlobal check, I wanted to reuse the "title" property already used in a few reps. 

This made me realise that we had a bug with grip and grip-array reps which were copying their title prop to their children. The first commit fixes that (as well as updating a test that relied on the bug).

The second commit adds the title prop to the window rep, as well as a TINY render mode. This means that now window objects will be rendered as Window (or their customized title) when they are  rendered in TINY mode. 

Comparing with the old console, this is a behaviour change, as the old console always displayed `Window -> url` it seems. I think this is an acceptable change though (and Chrome only displays `Window` for instance).

I'll wait for your feedback before adding tests dedicated to that.