### PR TITLE
allow window rep title customization from grip

### DIFF
--- a/src/reps/window.js
+++ b/src/reps/window.js
@@ -24,11 +24,10 @@ let Window = React.createClass({
     mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
     object: React.PropTypes.object.isRequired,
     objectLink: React.PropTypes.func,
-    title: React.PropTypes.string,
   },
 
   getTitle: function (object) {
-    let title = this.props.title || object.class || "Window";
+    let title = object.displayClass || object.class || "Window";
     if (this.props.objectLink) {
       return DOM.span({className: "objectBox"},
         this.props.objectLink({

--- a/src/test/mochitest/test_reps_window.html
+++ b/src/test/mochitest/test_reps_window.html
@@ -63,21 +63,20 @@ window.onload = Task.async(function* () {
     is(longRenderedComponent.textContent, "Window about:newtab",
        "Window rep has expected text content in LONG mode");
 
-    const customTitleRenderedComponent = renderComponent(Window.rep, {
-      object: gripStub,
+    const displayClassRenderedComponent = renderComponent(Window.rep, {
+      object: Object.assign({}, gripStub, {displayClass : "Custom"}),
       mode: MODE.TINY,
-      title: "Custom"
     });
-    is(customTitleRenderedComponent.textContent, "Custom",
-       "Window rep has expected text content in TINY mode with Custom title");
+    is(displayClassRenderedComponent.textContent, "Custom",
+       "Window rep has expected text content in TINY mode with Custom display class");
 
-    const customTitleLongRenderedComponent = renderComponent(Window.rep, {
-      object: gripStub,
+    const displayClassLongRenderedComponent = renderComponent(Window.rep, {
+      object: Object.assign({}, gripStub, {displayClass : "Custom"}),
       mode: MODE.LONG,
       title: "Custom"
     });
-    is(customTitleLongRenderedComponent.textContent, "Custom about:newtab",
-       "Window rep has expected text content in LONG mode with Custom title");
+    is(displayClassLongRenderedComponent.textContent, "Custom about:newtab",
+       "Window rep has expected text content in LONG mode with Custom display class");
   } catch(e) {
     ok(false, "Got an error: " + DevToolsUtils.safeErrorString(e));
   } finally {


### PR DESCRIPTION
cc @nchevobbe 

My previous attempt (PR #73 ) actually doesn't address the debugger needs. They need to be able to configure the window rep title from the grip itself and not from the rep. 

Looking at it more carefully I guess it makes more sense to make the title of this rep customizable based on the grip rather than on the rep's props.

So here I'm using an additional property displayClass in order to display a custom title for a window rep (to be consistent with `class` which is usually used as the title for the window rep).

I could re-add the option to also define this.props.title, but in this case we need to discuss the priority of this.props.title vs object.displayClass.

IMO it should be object.displayClass || this.props.title || object.class || "Window" ( but again I doubt a title at reps level here makes a lot of sense)
